### PR TITLE
Append our $PROMPT_COMMAND to the system's $PROMPT_COMMAND

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -40,7 +40,7 @@ c_git_clean='\[\e[0;32m\]'
 c_git_dirty='\[\e[0;31m\]'
 
 # PS1 is the variable for the prompt you see everytime you hit enter
-PROMPT_COMMAND='PS1="${c_path}\W${c_reset}$(git_prompt) :> "'
+PROMPT_COMMAND=$PROMPT_COMMAND' PS1="${c_path}\W${c_reset}$(git_prompt) :> "'
 
 export PS1='\n\[\033[0;31m\]\W\[\033[0m\]$(git_prompt)\[\033[0m\]:> '
 


### PR DESCRIPTION
Terminal.app depends on a system set `$PROMPT_COMMAND` to implement the
"Open tab in same working directory" feature. This appends our changes
onto the end of the system provided `$PROMPT_COMMAND` rather than
overwriting it. The people rejoice.