### PR TITLE
Fix terminal colors in El Capitan

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -40,9 +40,12 @@ c_git_clean='\[\e[0;32m\]'
 c_git_dirty='\[\e[0;31m\]'
 
 # PS1 is the variable for the prompt you see everytime you hit enter
-PROMPT_COMMAND=$PROMPT_COMMAND' PS1="${c_path}\W${c_reset}$(git_prompt) :> "'
-
-export PS1='\n\[\033[0;31m\]\W\[\033[0m\]$(git_prompt)\[\033[0m\]:> '
+if [ $ITERM_SESSION_ID ]
+then
+  PROMPT_COMMAND=$PROMPT_COMMAND' PS1="${c_path}\W${c_reset}$(git_prompt) :> "'
+else
+  PROMPT_COMMAND=$PROMPT_COMMAND'; PS1="${c_path}\W${c_reset}$(git_prompt) :> "'
+fi
 
 # determines if the git branch you are on is clean or dirty
 git_prompt ()


### PR DESCRIPTION
Me and some other DBC students, using macs running El Capitan, have had problems using Terminal with the .bash_profile from dotfiles. This code retains the "Open tab in same working directory" feature in Terminal, and displays the colors properly both in Terminal and in iTerm. It really seems to be all about that one ';'. I can't tell if this is going to be a long term bug, I haven't found anyone else on the wider internet talking about it.

I have not tested this outside El Capitan. This is my first real pull request, I fully expect you to know something I don't and say no. They may change something about Terminal again in the next update, making this superfluous or even re-breaking this. I'm trying to be proactive about improving the situation for students coming in, since it seems that a lot of students are switching to mac right before they start, increasing the chances that they will be running El Cap.