### PR TITLE
Revise Prompt Conditional

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -40,7 +40,7 @@ c_git_clean='\[\e[0;32m\]'
 c_git_dirty='\[\e[0;31m\]'
 
 # PS1 is the variable for the prompt you see everytime you hit enter
-if [ $OSTYPE == 'darwin15' ] && ! [ $ITERM_SESSION_ID ]
+if [ "$TERM_PROGRAM" == 'Apple_Terminal' ] && ! [ $ITERM_SESSION_ID ]
 then
   PROMPT_COMMAND=$PROMPT_COMMAND'; PS1="${c_path}\W${c_reset}$(git_prompt) :> "'
 else


### PR DESCRIPTION
Rather than use the $OSTYPE var, I ended up configuring mine to look for `Apple_Terminal` (I don't know what iTerm 2 calls itself), and as a result the error that I routinely saw in the IntelliJ IDEA Terminal disappeared! Woohoo!

IntelliJ IDEA Terminal also errored out on the unary operator, and oddly enough required quotes around the global variable (in case it's empty).